### PR TITLE
Add index to node_comment_statistics on comment_count

### DIFF
--- a/modules/comment/comment.install
+++ b/modules/comment/comment.install
@@ -66,6 +66,14 @@ function comment_update_6003() {
   return $ret;
 }
 
+/**
+ * Add index to to node_comment_statistics on comment_count
+ */
+function comment_update_6004() {
+  $ret = array();
+  db_add_index($ret, 'node_comment_statistics', 'comment_count', array('comment_count'));
+  return $ret;
+}
 
 /**
  * Implementation of hook_schema().
@@ -209,7 +217,8 @@ function comment_schema() {
     ),
     'primary key' => array('nid'),
     'indexes' => array(
-      'node_comment_timestamp' => array('last_comment_timestamp')
+      'node_comment_timestamp' => array('last_comment_timestamp'),
+      'comment_count' => array('comment_count'),
     ),
   );
 


### PR DESCRIPTION
This patch mirrors the changes from http://drupal.org/node/336483 to add index on node_comment_statistics. 

To summarize the rather lengthy d.o post, this is necessary because node_update_index() runs a full table scan on node_comment_statistics.
