### PR TITLE
backport drupal 7 db_ignore_slave function

### DIFF
--- a/includes/database.inc
+++ b/includes/database.inc
@@ -679,3 +679,24 @@ function db_type_placeholder($type) {
 /**
  * @} End of "defgroup schemaapi".
  */
+
+/**
+ * Sets a session variable specifying the lag time for ignoring a slave server.
+ * Backport of D7 functionality.
+ */
+function db_ignore_slave() {
+  global $active_slave_db;
+
+  // Only set ignore_slave_server if there are slave servers being used, which
+  // is assumed db_url is an array.
+  if (isset($active_slave_db)) {
+    // Five minutes is long enough to allow the slave to break and resume
+    // interrupted replication without causing problems on the Drupal site from
+    // the old data.
+    $duration = variable_get('maximum_replication_lag', 300);
+    // Set session variable with amount of time to delay before using slave.
+    // This will stick around for 5 minutes by default. 
+    // There is another $_Session variable 'not_slavesafe' for single queries.
+    $_SESSION['ignore_slave_server'] = $_SERVER['REQUEST_TIME'] + $duration;
+  }
+}

--- a/includes/database.mysql.inc
+++ b/includes/database.mysql.inc
@@ -98,6 +98,28 @@ function db_connect($url) {
 function _db_query($query, $debug = 0, $slave = FALSE) {
   global $active_db, $active_slave_db, $queries, $user;
 
+  // Ignore slave database servers for this request.
+  //
+  // In Drupal's distributed database structure, new data is written to the master
+  // and then propagated to the slave servers.  This means there is a lag
+  // between when data is written to the master and when it is available on the slave.
+  // At these times, we will want to avoid using a slave server temporarily.
+  // For example, if a user posts a new node then we want to disable the slave
+  // server for that user temporarily to allow the slave server to catch up.
+  // That way, that user will see their changes immediately while for other
+  // users we still get the benefits of having a slave server, just with slightly
+  // stale data.  Code that wants to disable the slave server should use the
+  // db_set_ignore_slave() function to set $_SESSION['ignore_slave_server'] to
+  // the timestamp after which the slave can be re-enabled.
+  if (isset($_SESSION['ignore_slave_server'])) {
+    if ($_SESSION['ignore_slave_server'] >= $_SERVER['REQUEST_TIME']) {
+      $slave = FALSE;
+    }
+    else {
+      unset($_SESSION['ignore_slave_server']);
+    }
+  }
+
   if (variable_get('dev_query', 0)) {
     list($usec, $sec) = explode(' ', microtime());
     $timer = (float)$usec + (float)$sec;

--- a/includes/database.mysqli.inc
+++ b/includes/database.mysqli.inc
@@ -97,6 +97,28 @@ function db_connect($url) {
 function _db_query($query, $debug = 0, $slave = FALSE) {
   global $active_db, $active_slave_db, $queries, $user;
 
+  // Ignore slave database servers for this request.
+  //
+  // In Drupal's distributed database structure, new data is written to the master
+  // and then propagated to the slave servers.  This means there is a lag
+  // between when data is written to the master and when it is available on the slave.
+  // At these times, we will want to avoid using a slave server temporarily.
+  // For example, if a user posts a new node then we want to disable the slave
+  // server for that user temporarily to allow the slave server to catch up.
+  // That way, that user will see their changes immediately while for other
+  // users we still get the benefits of having a slave server, just with slightly
+  // stale data.  Code that wants to disable the slave server should use the
+  // db_set_ignore_slave() function to set $_SESSION['ignore_slave_server'] to
+  // the timestamp after which the slave can be re-enabled.
+  if (isset($_SESSION['ignore_slave_server'])) {
+    if ($_SESSION['ignore_slave_server'] >= $_SERVER['REQUEST_TIME']) {
+      $slave = FALSE;
+    }
+    else {
+      unset($_SESSION['ignore_slave_server']);
+    }
+  }
+
   if (variable_get('dev_query', 0)) {
     list($usec, $sec) = explode(' ', microtime());
     $timer = (float)$usec + (float)$sec;

--- a/modules/comment/comment.module
+++ b/modules/comment/comment.module
@@ -774,6 +774,10 @@ function comment_save($edit) {
       // Clear the cache so an anonymous user can see his comment being added.
       cache_clear_all();
 
+      // Ignore slave server temporarily to give time for the
+      // saved comment to be propagated to the slave.
+      db_ignore_slave();
+
       // Explain the approval queue if necessary, and then
       // redirect the user to the node he's commenting on.
       if ($edit['status'] == COMMENT_NOT_PUBLISHED) {

--- a/modules/node/node.module
+++ b/modules/node/node.module
@@ -941,6 +941,10 @@ function node_save(&$node) {
 
   // Clear the page and block caches.
   cache_clear_all();
+
+  // Ignore slave server temporarily to give time for the
+  // saved node to be propagated to the slave.
+  db_ignore_slave();
 }
 
 /**


### PR DESCRIPTION
This branch backports the db_ignore_slave() function that is in d7 into Pressflow for Drupal 6.

What it does: When a node or comment is saved all queries for the current user are sent to the master db for a set amount of time (default 5 min). This provides a guarantee that the content they are viewing shows the changes that they saved just saved. When saving complicated node relationships this patch also insures that code that saves new nodes has the most recent changes.
