### PR TITLE
Restore the has_js cookie for authenticated users

### DIFF
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -2180,6 +2180,12 @@ function drupal_add_js($data = NULL, $type = 'module', $scope = 'header', $defer
         ),
         'inline' => array(),
       );
+      // We never cache authenticated user pages, so if they are logged in we
+      // allow setting of the has_js cookie so batch API functions use the JS
+      // version.
+      if (!user_is_anonymous()) {
+        $javascript['footer']['inline'][] = array('code' => "document.cookie = 'has_js=1; path=/';", 'defer' => TRUE);
+      }
     }
 
     if (isset($scope) && !isset($javascript[$scope])) {


### PR DESCRIPTION
This is an simpler version of https://github.com/pressflow/6/pull/9 that just sets the has_js cookie using inline script in the footer if the user is authenticated.
