### PR TITLE
Improve the performance of db_prefix_tables when many prefixes are used

### DIFF
--- a/includes/database.inc
+++ b/includes/database.inc
@@ -81,25 +81,35 @@ function update_sql($sql) {
 function db_prefix_tables($sql) {
   global $db_prefix;
 
-  if (is_array($db_prefix)) {
-    if (array_key_exists('default', $db_prefix)) {
-      $tmp = $db_prefix;
-      unset($tmp['default']);
-      foreach ($tmp as $key => $val) {
-        $sql = strtr($sql, array('{'. $key .'}' => $val . $key));
-      }
-      return strtr($sql, array('{' => $db_prefix['default'], '}' => ''));
-    }
-    else {
-      foreach ($db_prefix as $key => $val) {
-        $sql = strtr($sql, array('{'. $key .'}' => $val . $key));
-      }
-      return strtr($sql, array('{' => '', '}' => ''));
-    }
-  }
-  else {
+  // Simple case, db_prefix is not an array, therefore we can do a single
+  // replacement operation.
+  if (!is_array($db_prefix)) {
     return strtr($sql, array('{' => $db_prefix, '}' => ''));
   }
+
+  return preg_replace_callback('/{.+?}/', '_db_prefix_tables_callback', $sql);
+}
+
+/**
+ * Callback function for the preg_replace_callback in db_prefix_tables.
+ */
+function _db_prefix_tables_callback($matches) {
+  global $db_prefix;
+  $table = trim($matches[0], '{}');
+
+  if (isset($db_prefix[$table])) {
+    // This table has been specifically mentioned in the $db_prefixes.
+    $prefix = $db_prefix[$table];
+  }
+  elseif (isset($db_prefix['default'])) {
+    // Default prefix is defined, use that.
+    $prefix = $db_prefix['default'];
+  }
+  else {
+    $prefix = '';
+  }
+
+  return $prefix . $table;
 }
 
 /**


### PR DESCRIPTION
Here is the Drupal.org issue, and this patch: http://drupal.org/node/561422#comment-5592350

The running time of the function db_prefix_tables() grows linearly as the number of prefixes in $db_prefix array increases. Our client has 151 entries in this array, and thus we are seeing a significant amount of time spent prefixing table names in SQL strings. On page requests with many queries, this could be 50% of the page load time, as the db_prefix_tables function is poorly optimized for large arrays of prefixes.

The patch uses preg_replace_callback to achieve the same thing, and uses the default Drupal behavior in cases where there is 1 or 0 db_prefixes, which is the safest way to go about this.

Hoping this gets committed to Drupal 6, however client would like to upgrade to Pressflow so proposing this patch.
