### PR TITLE
Backport of jQuery noconflict

### DIFF
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -2122,6 +2122,8 @@ function drupal_clear_css_cache() {
  *   Executes a piece of JavaScript code on the current page by placing the code
  *   directly in the page. This can, for example, be useful to tell the user that
  *   a new message arrived, by opening a pop up, alert box etc.
+ *   When adding inline code, make sure that you are not relying ont $ being jQuery.
+ *   Wrap your code in (function($) { ... })(jQuery); or use jQuery instead of $.
  *
  * - Add settings ('setting'):
  *   Adds a setting to Drupal's global storage of JavaScript settings. Per-page

--- a/install.php
+++ b/install.php
@@ -745,7 +745,7 @@ function install_tasks($profile, $task) {
       drupal_add_js('
 // Global Killswitch
 if (Drupal.jsEnabled) {
-  $(document).ready(function() {
+  jQuery(document).ready(function() {
     Drupal.cleanURLsInstallCheck();
     Drupal.setDefaultTimezone();
   });

--- a/misc/ahah.js
+++ b/misc/ahah.js
@@ -1,3 +1,4 @@
+(function($) {
 
 /**
  * Provides AJAX-like page updating via AHAH (Asynchronous HTML and HTTP).
@@ -135,7 +136,7 @@ Drupal.ahah.prototype.beforeSubmit = function (form_values, element, options) {
   else if (this.progress.type == 'throbber') {
     this.progress.element = $('<div class="ahah-progress ahah-progress-throbber"><div class="throbber">&nbsp;</div></div>');
     if (this.progress.message) {
-      $('.throbber', this.progress.element).after('<div class="message">' + this.progress.message + '</div>')
+      $('.throbber', this.progress.element).after('<div class="message">' + this.progress.message + '</div>');
     }
     $(this.element).after(this.progress.element);
   }
@@ -222,3 +223,5 @@ Drupal.ahah.prototype.error = function (response, uri) {
   // Re-enable the element.
   $(this.element).removeClass('progess-disabled').attr('disabled', false);
 };
+
+})(jQuery);

--- a/misc/autocomplete.js
+++ b/misc/autocomplete.js
@@ -1,3 +1,4 @@
+(function($) {
 
 /**
  * Attaches the autocomplete behavior to all required fields
@@ -295,3 +296,5 @@ Drupal.ACDB.prototype.cancel = function() {
   if (this.timer) clearTimeout(this.timer);
   this.searchString = '';
 };
+
+})(jQuery);

--- a/misc/batch.js
+++ b/misc/batch.js
@@ -1,3 +1,4 @@
+(function($) {
 
 /**
  * Attaches the batch behavior to progress bars.
@@ -35,3 +36,5 @@ Drupal.behaviors.batch = function (context) {
     progress.startMonitoring(uri+'&op=do', 10);
   });
 };
+
+})(jQuery);

--- a/misc/collapse.js
+++ b/misc/collapse.js
@@ -1,3 +1,4 @@
+(function($) {
 
 /**
  * Toggle the visibility of a fieldset using smooth animations
@@ -74,3 +75,5 @@ Drupal.behaviors.collapse = function (context) {
       .addClass('collapse-processed');
   });
 };
+
+})(jQuery);

--- a/misc/drupal.js
+++ b/misc/drupal.js
@@ -1,6 +1,11 @@
 
 var Drupal = Drupal || { 'settings': {}, 'behaviors': {}, 'themes': {}, 'locale': {} };
 
+// Allow other JavaScript libraries to use $.
+jQuery.noConflict();
+
+(function($) {
+
 /**
  * Set the variable that indicates if JavaScript behaviors should be applied
  */
@@ -250,7 +255,7 @@ Drupal.getSelection = function (element) {
  */
 Drupal.ahahError = function(xmlhttp, uri) {
   if (xmlhttp.status == 200) {
-    if (jQuery.trim(xmlhttp.responseText)) {
+    if ($.trim(xmlhttp.responseText)) {
       var message = Drupal.t("An error occurred. \n@uri\n@text", {'@uri': uri, '@text': xmlhttp.responseText });
     }
     else {
@@ -287,3 +292,5 @@ Drupal.theme.prototype = {
     return '<em>' + Drupal.checkPlain(str) + '</em>';
   }
 };
+
+})(jQuery);

--- a/misc/farbtastic/farbtastic.js
+++ b/misc/farbtastic/farbtastic.js
@@ -1,16 +1,17 @@
 // Farbtastic 1.2
+(function($) {
 
-jQuery.fn.farbtastic = function (callback) {
+$.fn.farbtastic = function (callback) {
   $.farbtastic(this, callback);
   return this;
 };
 
-jQuery.farbtastic = function (container, callback) {
+$.farbtastic = function (container, callback) {
   var container = $(container).get(0);
-  return container.farbtastic || (container.farbtastic = new jQuery._farbtastic(container, callback));
+  return container.farbtastic || (container.farbtastic = new $._farbtastic(container, callback));
 };
 
-jQuery._farbtastic = function (container, callback) {
+$._farbtastic = function (container, callback) {
   // Store farbtastic object
   var fb = this;
 
@@ -312,3 +313,5 @@ jQuery._farbtastic = function (container, callback) {
     fb.linkTo(callback);
   }
 };
+
+})(jQuery);

--- a/misc/form.js
+++ b/misc/form.js
@@ -1,3 +1,4 @@
+(function($) {
 
 Drupal.behaviors.multiselectSelector = function() {
   // Automatically selects the right radio button in a multiselect control.
@@ -7,3 +8,5 @@ Drupal.behaviors.multiselectSelector = function() {
         .attr('checked', true);
   });
 };
+
+})(jQuery);

--- a/misc/progress.js
+++ b/misc/progress.js
@@ -1,3 +1,4 @@
+(function($) {
 
 /**
  * A progressbar object. Initialized with the given id. Must be inserted into
@@ -104,3 +105,5 @@ Drupal.progressBar.prototype.displayError = function (string) {
     this.errorCallback(this);
   }
 };
+
+})(jQuery);

--- a/misc/tabledrag.js
+++ b/misc/tabledrag.js
@@ -1,3 +1,4 @@
+(function($) {
 
 /**
  * Drag and drop table rows with field manipulation.
@@ -321,7 +322,9 @@ Drupal.tableDrag.prototype.makeDraggable = function(item) {
             var groupHeight = 0;
             nextGroup = new self.row(nextRow, 'keyboard', self.indentEnabled, self.maxDepth, false);
             if (nextGroup) {
-              $(nextGroup.group).each(function () {groupHeight += $(this).is(':hidden') ? 0 : this.offsetHeight});
+              $(nextGroup.group).each(function () { 
+                groupHeight += $(this).is(':hidden') ? 0 : this.offsetHeight;
+              });
               nextGroupRow = $(nextGroup.group).filter(':last').get(0);
               self.rowObject.swap('after', nextGroupRow);
               // No need to check for indentation, 0 is the only valid one.
@@ -958,7 +961,7 @@ Drupal.tableDrag.prototype.row.prototype.validIndentInterval = function (prevRow
   }
 
   return {'min':minIndent, 'max':maxIndent};
-}
+};
 
 /**
  * Indent a row within the legal bounds of the table.
@@ -1022,7 +1025,7 @@ Drupal.tableDrag.prototype.row.prototype.findSiblings = function(rowSettings) {
         // Either add immediately if this is a flat table, or check to ensure
         // that this row has the same level of indentaiton.
         if (this.indentEnabled) {
-          var checkRowIndentation = $('.indentation', checkRow).length
+          var checkRowIndentation = $('.indentation', checkRow).length;
         }
 
         if (!(this.indentEnabled) || (checkRowIndentation == rowIndentation)) {
@@ -1097,3 +1100,5 @@ Drupal.theme.prototype.tableDragIndentation = function () {
 Drupal.theme.prototype.tableDragChangedWarning = function () {
   return '<div class="warning">' + Drupal.theme('tableDragChangedMarker') + ' ' + Drupal.t("Changes made in this table will not be saved until the form is submitted.") + '</div>';
 };
+
+})(jQuery);

--- a/misc/tableheader.js
+++ b/misc/tableheader.js
@@ -1,3 +1,4 @@
+(function($) {
 
 Drupal.tableHeaderDoScroll = function() {
   if (typeof(Drupal.tableHeaderOnScroll)=='function') {
@@ -114,3 +115,5 @@ Drupal.behaviors.tableHeader = function (context) {
   };
   $(window).resize(resize);
 };
+
+})(jQuery);

--- a/misc/tableselect.js
+++ b/misc/tableselect.js
@@ -1,3 +1,4 @@
+(function($) {
 
 Drupal.behaviors.tableSelect = function (context) {
   $('form table:has(th.select-all):not(.tableSelect-processed)', context).each(Drupal.tableSelect);
@@ -79,8 +80,10 @@ Drupal.tableSelectRange = function(from, to, state) {
       }
     }
     // A faster alternative to doing $(i).filter(to).length.
-    else if (jQuery.filter(to, [i]).r.length) {
+    else if ($.filter(to, [i]).r.length) {
       break;
     }
   }
 };
+
+})(jQuery);

--- a/misc/teaser.js
+++ b/misc/teaser.js
@@ -1,3 +1,4 @@
+(function($) {
 
 /**
  * Auto-attach for teaser behavior.
@@ -93,3 +94,5 @@ Drupal.behaviors.teaser = function(context) {
 
   });
 };
+
+})(jQuery);

--- a/misc/textarea.js
+++ b/misc/textarea.js
@@ -1,4 +1,4 @@
-
+(function($) {
 Drupal.behaviors.textarea = function(context) {
   $('textarea.resizable:not(.textarea-processed)', context).each(function() {
     // Avoid non-processed teasers.
@@ -33,3 +33,5 @@ Drupal.behaviors.textarea = function(context) {
     }
   });
 };
+
+})(jQuery);

--- a/modules/block/block.js
+++ b/modules/block/block.js
@@ -1,3 +1,4 @@
+(function($) {
 
 /**
  * Move a block in the blocks table from one region to another via select list.
@@ -92,3 +93,5 @@ Drupal.behaviors.blockDrag = function(context) {
     });
   };
 };
+
+})(jQuery);

--- a/modules/book/book.module
+++ b/modules/book/book.module
@@ -361,7 +361,7 @@ function _book_parent_select($book_link) {
 function _book_add_form_elements(&$form, $node) {
   // Need this for AJAX.
   $form['#cache'] = TRUE;
-  drupal_add_js("if (Drupal.jsEnabled) { $(document).ready(function() { $('#edit-book-pick-book').css('display', 'none'); }); }", 'inline');
+  drupal_add_js("if (Drupal.jsEnabled) { jQuery(function() { jQuery('#edit-book-pick-book').css('display', 'none'); }); }", 'inline');
 
   $form['book'] = array(
     '#type' => 'fieldset',

--- a/modules/color/color.js
+++ b/modules/color/color.js
@@ -1,3 +1,4 @@
+(function($) {
 
 Drupal.behaviors.color = function (context) {
   // This behavior attaches by ID, so is only valid once on a page.
@@ -248,3 +249,5 @@ Drupal.behaviors.color = function (context) {
   // Render preview
   preview();
 };
+
+})(jQuery);

--- a/modules/comment/comment.js
+++ b/modules/comment/comment.js
@@ -1,3 +1,4 @@
+(function($) {
 
 Drupal.behaviors.comment = function (context) {
   var parts = new Array("name", "homepage", "mail");
@@ -32,3 +33,5 @@ Drupal.comment.getCookie = function(name) {
 
   return returnValue;
 };
+
+})(jQuery);

--- a/modules/profile/profile.js
+++ b/modules/profile/profile.js
@@ -1,3 +1,4 @@
+(function($) {
 
 /**
  * Add functionality to the profile drag and drop table.
@@ -51,3 +52,5 @@ Drupal.behaviors.profileDrag = function(context) {
     }
   };
 };
+
+})(jQuery);

--- a/modules/simpletest/simpletest.js
+++ b/modules/simpletest/simpletest.js
@@ -1,6 +1,6 @@
 // $Id: simpletest.js,v 1.2.4.6 2009/12/14 23:29:36 boombatower Exp $
 // Core: Id: simpletest.js,v 1.11 2009/04/27 20:19:37 webchick Exp
-//(function ($) {
+(function ($) {
 
 /**
  * Add the cool table collapsing on the testing overview page.
@@ -111,4 +111,4 @@ Drupal.behaviors.simpleTestSelectAll = function() {
 //  }
 };
 
-//})(jQuery);
+})(jQuery);

--- a/modules/system/system.js
+++ b/modules/system/system.js
@@ -1,3 +1,4 @@
+(function($) {
 
 /**
  * Internal function to check using Ajax if clean URLs can be enabled on the
@@ -73,7 +74,7 @@ Drupal.behaviors.copyFieldValue = function (context) {
   for (var sourceId in Drupal.settings.copyFieldValue) {
     // Get the list of target fields.
     targetIds = Drupal.settings.copyFieldValue[sourceId];
-    if (!$('#'+ sourceId + '.copy-field-values-processed').size(), context) {
+    if (!$('#'+ sourceId + '.copy-field-values-processed', context).size()) {`
       // Add the behavior to update target fields on blur of the primary field.
       sourceField = $('#' + sourceId);
       sourceField.bind('blur', function() {
@@ -110,3 +111,5 @@ Drupal.behaviors.dateTime = function(context) {
   // Trigger the event handler to show the form input if necessary.
   $('select.date-format', context).trigger('change');
 };
+
+})(jQuery);

--- a/modules/taxonomy/taxonomy.js
+++ b/modules/taxonomy/taxonomy.js
@@ -1,3 +1,4 @@
+(function($) {
 
 /**
  * Move a block in the blocks table from one region to another via select list.
@@ -33,3 +34,5 @@ Drupal.behaviors.termDrag = function(context) {
     }
   };
 };
+
+})(jQuery);

--- a/modules/user/user.js
+++ b/modules/user/user.js
@@ -1,3 +1,4 @@
+(function($) {
 
 /**
  * Attach handlers to evaluate the strength of any password fields and to check
@@ -185,3 +186,4 @@ Drupal.behaviors.userSettings = function (context) {
   });
 };
 
+})(jQuery);


### PR DESCRIPTION
This pull request backports the jQuery noconflict work introduced in D7 here: [http://drupal.org/node/125030].

This is desirable so that other JavaScript libraries that use the $ variable won't interfere with jQuery. To be fully compliant, contributed modules would still need to wrap their JavaScript with `(function($) { ... })(jQuery);` but some of the big ones already do (i.e. CTools, Panels, WYSIWYG, etc).

This change will not break modules that do not wrap their JavaScript, a site using a contributed module that doesn't wrap its JS just won't be able to use another JS library that uses the $ variable.
