### PR TITLE
#9 by @deviantintegral and @pwolanin

### DIFF
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -2224,7 +2224,7 @@ function drupal_add_js($data = NULL, $type = 'module', $scope = 'header', $defer
       // user_is_anonymous() is not used here because it is unavailable during
       // installation.
       // @see user_is_anonymous()
-      if (!empty($GLOBALS['user']->uid) || isset($GLOBALS['menu_admin'])) {
+      if (!empty($GLOBALS['user']->uid) || !empty($GLOBALS['menu_admin'])) {
         $javascript['footer']['inline'][] = array('code' => "document.cookie = 'has_js=1; path=/';", 'defer' => TRUE);
       }
     }


### PR DESCRIPTION
Re-working of #9 and #23: Set the has_js cookie for authenticated users.

user_is_anonymous() works fine in all cases except on install where the user module isn't installed yet.

FWIW, the has_js cookie is used in batch.inc to provide the JS version of the batch progress bar.
