### PR TITLE
Fix incorrect cache variable name preventing proper page cache ...

### DIFF
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -2714,7 +2714,7 @@ function page_set_cache() {
     // This will fail in some cases, see page_get_cache() for the explanation.
     if ($data = ob_get_contents()) {
       ob_end_clean();
-      $cache_lifetime = variable_get('page_cache_lifetime', 0);
+      $cache_lifetime = variable_get('cache_lifetime', 0);
 
       if (variable_get('page_compression', TRUE) && extension_loaded('zlib')) {
         $data = gzencode($data, 9, FORCE_GZIP);


### PR DESCRIPTION
Fix incorrect cache variable name. page_cache_lifetime is invalid variable name because it isn't set or used anywhere. This bug prevents Drupal from enforcing minimum cache_lifetime for pages. Without this change, even if Minimum cache lifetime (Settings->Performance) is set to 1 minute, page will still be cached for CACHE_TEMPORARY.
