### PR TITLE
Trivial has_js patch

### DIFF
--- a/misc/drupal.js
+++ b/misc/drupal.js
@@ -1,4 +1,3 @@
-
 var Drupal = Drupal || { 'settings': {}, 'behaviors': {}, 'themes': {}, 'locale': {} };
 
 /**
@@ -265,10 +264,13 @@ Drupal.ahahError = function(xmlhttp, uri) {
 
 // Global Killswitch on the <html> element
 $(document.documentElement).addClass('js');
+// Allow batch operations to run using JS.
+document.cookie = 'has_js=1; path=/batch';
 // Attach all behaviors.
 $(document).ready(function() {
   Drupal.attachBehaviors(this);
 });
+
 
 /**
  * The default themes.


### PR DESCRIPTION
I remember a merge proposal on launchpad to allow batch to work in JS mode with the has_js cookie. The approach here is not perfect as it assumes the site runs at the root of the host. This is possibly ok on a Pressflow install although not perfect. Drupal, in Javascript, sets the has_js cookie on / so it doesn't care about the true root either although / is slightly more glamorous.

With this approach or a similar path based one the rest of the site URLs should be ok and cookie less.  Thoughts?
