### PR TITLE
cookie_cache_bypass: don't form_alter when executed from Drush

### DIFF
--- a/modules/cookie_cache_bypass/cookie_cache_bypass.module
+++ b/modules/cookie_cache_bypass/cookie_cache_bypass.module
@@ -1,7 +1,11 @@
 <?php
 
 function cookie_cache_bypass_form_alter(&$form, $form_state, $form_id) {
-  $form['#submit'][] = 'cookie_cache_bypass_submit';
+  // Only add the custom bypass code if not executing via the command line,
+  // i.e. drush.
+  if (php_sapi_name() != 'cli') {
+    $form['#submit'][] = 'cookie_cache_bypass_submit';
+  }
 }
 
 function cookie_cache_bypass_submit() {


### PR DESCRIPTION
When using Drush the cookie_cache_bypass module doesn't need to do the setcookie() command. This code uses php_sapi_name() to first verify that it is not executing via 'cli' before adding the custom form submission callback.
