### PR TITLE
Added the blockcache_bypass_node_grants variable.

### DIFF
--- a/modules/block/block.module
+++ b/modules/block/block.module
@@ -519,7 +519,8 @@ function block_list($region) {
           // Try fetching the block from cache. Block caching is not compatible with
           // node_access modules. We also preserve the submission of forms in blocks,
           // by fetching from cache only if the request method is 'GET'.
-          if (!count(module_implements('node_grants')) && $_SERVER['REQUEST_METHOD'] == 'GET' && ($cid = _block_get_cache_id($block)) && ($cache = cache_get($cid, 'cache_block'))) {
+          $blockcache_node_grants = variable_get('block_cache_node_access_bypass', FALSE) || !count(module_implements('node_grants'));
+          if ($blockcache_node_grants && $_SERVER['REQUEST_METHOD'] == 'GET' && ($cid = _block_get_cache_id($block)) && ($cache = cache_get($cid, 'cache_block'))) {
             $array = $cache->data;
           }
           else {

--- a/modules/system/system.admin.inc
+++ b/modules/system/system.admin.inc
@@ -1345,7 +1345,7 @@ function system_performance_settings() {
     '#title' => t('Block cache'),
     '#default_value' => variable_get('block_cache', CACHE_DISABLED),
     '#options' => array(CACHE_DISABLED => t('Disabled'), CACHE_NORMAL => t('Enabled (recommended)')),
-    '#disabled' => count(module_implements('node_grants')),
+    '#disabled' => !variable_get('block_cache_node_access_bypass', FALSE) || count(module_implements('node_grants')),
     '#description' => t('Note that block caching is inactive when modules defining content access restrictions are enabled.'),
   );
 


### PR DESCRIPTION
Core's decision to completely disable block cache if any module implements node_grants is a bit overprotective. If you know how your node_grants modules work and you only apply block cache to blocks you know are safe, there's no reason you should have to resort to hacking core to get this functionaliy.

This patch introduces a block_cache_node_access_bypass variable that can be set in $conf that will bypass this check.

I've got similar patches for D8 and D7 in the core queue (http://drupal.org/node/186636#comment-5869514), but it seems unlikely that I'd get this into D6, so I'm thinking it makes more sense to go straight into pressflow.
