### PR TITLE
Fix sticky headers after ajax request.

### DIFF
--- a/misc/tableheader.js
+++ b/misc/tableheader.js
@@ -13,7 +13,7 @@ Drupal.behaviors.tableHeader = function (context) {
 
   // Keep track of all cloned table headers.
   var headers = [];
-
+  $(".sticky-header").each(function(i, el){headers.push(el);});
   $('table.sticky-enabled thead:not(.tableHeader-processed)', context).each(function () {
     // Clone thead so it inherits original jQuery properties.
     var headerClone = $(this).clone(true).insertBefore(this.parentNode).wrap('<table class="sticky-header"></table>').parent().css({


### PR DESCRIPTION
Drupal core bug. See https://drupal.org/node/1253952
