### PR TITLE
Fix empty session id.

### DIFF
--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -1715,7 +1715,9 @@ function drupal_session_initialize() {
    
   session_set_save_handler('sess_open', 'sess_close', 'sess_read', 'sess_write', 'sess_destroy_sid', 'sess_gc');
  
-  if (isset($_COOKIE[session_name()])) {
+  // Use !empty() in the following check to ensure that blank session IDs
+  // are not valid.
+  if (!empty($_COOKIE[session_name()])) {
     // If a session cookie exists, initialize the session. Otherwise the
     // session is only started on demand in drupal_session_commit(), making
     // anonymous users not use a session cookie unless something is stored in


### PR DESCRIPTION
There is a bug in core Drupal, which has been fixed in Drupal 7, need same fix in 6 "The session is created with an empty string sid".
Here is a possible fix, should use !empty(), rather than isset(), to ensure that blank session IDs are not valid.
