### PR TITLE
Use real HMAC function in simpletest

### DIFF
--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -2073,20 +2073,13 @@ function drupal_random_bytes($count) {
  * @param string $key
  *   A secret string key.
  *
- * See RFC2104 (http://www.ietf.org/rfc/rfc2104.txt). Note, the result of this
- * must be identical to using hash_hmac('sha1', $data, $key);  We don't use
- * that function since PHP can be missing it if it was compiled with the
- * --disable-hash switch.
+ * See RFC2104 (http://www.ietf.org/rfc/rfc2104.txt).
  *
  * @return string
  *   A hexadecimal encoded sha-1 hmac.
  */
 function drupal_hash_hmac_sha1($data, $key) {
-  // Keys longer than the 64 byte block size must be hashed first.
-  if (strlen($key) > 64) {
-    $key = pack("H*", sha1($key));
-  }
-  return sha1((str_pad($key, 64, chr(0x00)) ^ (str_repeat(chr(0x5c), 64))) . pack("H*", sha1((str_pad($key, 64, chr(0x00)) ^ (str_repeat(chr(0x36), 64))) . $data)));
+  return hash_hmac('sha1', $data, $key);
 }
 
 /**

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -1907,7 +1907,7 @@ function drupal_valid_test_ua($user_agent) {
 //  $key = sha1(serialize($databases) . filectime($filepath) . fileinode($filepath), TRUE);
   $key = sha1(serialize($db_url) . filectime($filepath) . fileinode($filepath), TRUE);
   // The HMAC must match.
-  return $hmac == drupal_base64_encode(hash_hmac('sha1', $check_string, $key, TRUE));
+  return $hmac == drupal_hmac_base64($check_string, $key));
 }
 
 /**
@@ -1930,7 +1930,7 @@ function drupal_generate_test_ua($prefix) {
    // Generate a moderately secure HMAC based on the database credentials.
    $salt = uniqid('', TRUE);
    $check_string = $prefix . ';' . time() . ';' . $salt;
-   return  $check_string . ';' . drupal_base64_encode(hash_hmac('sha1', $check_string, $key, TRUE));
+   return $check_string . ';' . drupal_hmac_base64($check_string, $key));
 }
 
 /**


### PR DESCRIPTION
So here's a thing, I didn't really look for the link but long ago there was a this discussion in the simpletest queue to fix 500 errors because drupal_base64_encode makes values invalid in headers. Now core has backported HMAC method that creates valid values so we can use it.
