### PR TITLE
Fix broken Pressflow page cache lifetime

### DIFF
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -2752,7 +2752,7 @@ function page_set_cache() {
     // This will fail in some cases, see page_get_cache() for the explanation.
     if ($data = ob_get_contents()) {
       ob_end_clean();
-      $cache_lifetime = variable_get('page_cache_lifetime', 0);
+      $cache_lifetime = variable_get('cache_lifetime', 0);
 
       if (variable_get('page_compression', TRUE) && extension_loaded('zlib')) {
         $data = gzencode($data, 9, FORCE_GZIP);
@@ -2761,7 +2761,7 @@ function page_set_cache() {
       $cache = (object) array(
         'cid' => $base_root . request_uri(),
         'data' => $data,
-        'expire' => $cache_lifetime > 0 ? $cache_lifetime : CACHE_TEMPORARY,
+        'expire' => $cache_lifetime > 0 ? $_SERVER['REQUEST_TIME'] + $cache_lifetime : CACHE_TEMPORARY,
         'created' => $_SERVER['REQUEST_TIME'],
         'headers' => array(),
       );


### PR DESCRIPTION
Fix broken Pressflow page cache lifetime due to use of non-existent config variable, and incorrectly treating it as a timestamp.

It looks like at some stage someone has tried to fix the default Drupal behaviour of caching pages with CACHE_TEMPORARY. However it has never worked because 1. the wrong variable name is used and 2. even if the correct variable name had been used, the variable stores a TTL but cache_set requires a timestamp.

See
https://github.com/pressflow/6/pull/33 (earlier incomplete pull request)
https://www.drupal.org/node/1279654
https://www.drupal.org/node/2130865
