### PR TITLE
Merge tag '6.38' into pressflow-6.38

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,9 @@
 
+Drupal 6.38, 2016-02-24 - Final release
+---------------------------------------
+- Fixed security issues (multiple vulnerabilities). See SA-CORE-2016-001.
+- Previously unreleased documentation fixes.
+
 Drupal 6.37, 2015-08-19
 -----------------------
 - Fixed security issues (multiple vulnerabilities). See SA-CORE-2015-003.
@@ -8,52 +13,52 @@ Drupal 6.36, 2015-06-17
 - Fixed security issues (OpenID impersonation). See SA-CORE-2015-002.
 
 Drupal 6.35, 2015-03-18
-----------------------
+-----------------------
 - Fixed security issues (multiple vulnerabilities). See SA-CORE-2015-001.
 
 Drupal 6.34, 2014-11-19
-----------------------
+-----------------------
 - Fixed security issues (session hijacking). See SA-CORE-2014-006.
 
 Drupal 6.33, 2014-08-06
-----------------------
+-----------------------
 - Fixed security issues (denial of service). See SA-CORE-2014-004.
 
 Drupal 6.32, 2014-07-16
-----------------------
+-----------------------
 - Fixed security issues (multiple vulnerabilities). See SA-CORE-2014-003.
 
 Drupal 6.31, 2014-04-16
-----------------------
+-----------------------
 - Fixed security issues (information disclosure). See SA-CORE-2014-002.
 
 Drupal 6.30, 2014-01-15
-----------------------
-- Fixed security issues (multiple vulnerabilities), see SA-CORE-2014-001.
+-----------------------
+- Fixed security issues (multiple vulnerabilities). See SA-CORE-2014-001.
 
 Drupal 6.29, 2013-11-20
-----------------------
-- Fixed security issues (multiple vulnerabilities), see SA-CORE-2013-003.
+-----------------------
+- Fixed security issues (multiple vulnerabilities). See SA-CORE-2013-003.
 
 Drupal 6.28, 2013-01-16
-----------------------
-- Fixed security issues (multiple vulnerabilities), see SA-CORE-2013-001.
+-----------------------
+- Fixed security issues (multiple vulnerabilities). See SA-CORE-2013-001.
 
 Drupal 6.27, 2012-12-19
-----------------------
-- Fixed security issues (multiple vulnerabilities), see SA-CORE-2012-004.
+-----------------------
+- Fixed security issues (multiple vulnerabilities). See SA-CORE-2012-004.
 
 Drupal 6.26, 2012-05-02
-----------------------
+-----------------------
 - Fixed a small number of bugs.
 - Made code documentation improvements.
 
 Drupal 6.25, 2012-02-29
-----------------------
+-----------------------
 - Fixed regressions introduced in Drupal 6.24 only.
 
 Drupal 6.24, 2012-02-01
-----------------------
+-----------------------
 - Improved performance of search indexing and user operations by adding indexes.
 - Fixed issues with themes getting disabled due to missing locking in
   system_theme_data().
@@ -63,36 +68,36 @@ Drupal 6.24, 2012-02-01
 - Fixed a variety of other bugs.
 
 Drupal 6.23, 2012-02-01
-----------------------
-- Fixed security issues (Cross site scripting), see SA-CORE-2012-001.
+-----------------------
+- Fixed security issues (Cross site scripting). See SA-CORE-2012-001.
 
 Drupal 6.22, 2011-05-25
-----------------------
+-----------------------
 - Made Drupal 6 work better with IIS and Internet Explorer.
 - Fixed .po file imports to work better with custom textgroups.
 - Improved code documentation at various places.
 - Fixed a variety of other bugs.
 
 Drupal 6.21, 2011-05-25
-----------------------
-- Fixed security issues (Cross site scripting), see SA-CORE-2011-001.
+-----------------------
+- Fixed security issues (Cross site scripting). See SA-CORE-2011-001.
 
 Drupal 6.20, 2010-12-15
-----------------------
+-----------------------
 - Fixed a variety of small bugs, improved code documentation.
 
 Drupal 6.19, 2010-08-11
-----------------------
+-----------------------
 - Fixed a variety of small bugs, improved code documentation.
 
 Drupal 6.18, 2010-08-11
-----------------------
+-----------------------
 - Fixed security issues (OpenID authentication bypass, File download access
   bypass, Comment unpublishing bypass, Actions cross site scripting),
   see SA-CORE-2010-002.
 
 Drupal 6.17, 2010-06-02
-----------------------
+-----------------------
 - Improved PostgreSQL compatibility
 - Better PHP 5.3 and PHP 4 compatibility
 - Better browser compatibility of CSS and JS aggregation
@@ -101,7 +106,7 @@ Drupal 6.17, 2010-06-02
 - Fixed a variety of other bugs.
 
 Drupal 6.16, 2010-03-03
-----------------------
+-----------------------
 - Fixed security issues (Installation cross site scripting, Open redirection,
   Locale module cross site scripting, Blocked user session regeneration),
   see SA-CORE-2010-001.
@@ -113,42 +118,42 @@ Drupal 6.16, 2010-03-03
 - Fixed a variety of other bugs.
 
 Drupal 6.15, 2009-12-16
-----------------------
-- Fixed security issues (Cross site scripting), see SA-CORE-2009-009.
+-----------------------
+- Fixed security issues (Cross site scripting). See SA-CORE-2009-009.
 - Fixed a variety of other bugs.
 
 Drupal 6.14, 2009-09-16
-----------------------
+-----------------------
 - Fixed security issues (OpenID association cross site request forgeries,
-  OpenID impersonation and File upload), see SA-CORE-2009-008.
+  OpenID impersonation and File upload). See SA-CORE-2009-008.
 - Changed the system modules page to not run all cache rebuilds; use the
   button on the performance settings page to achieve the same effect.
 - Added support for PHP 5.3.0 out of the box.
 - Fixed a variety of small bugs.
 
 Drupal 6.13, 2009-07-01
-----------------------
+-----------------------
 - Fixed security issues (Cross site scripting, Input format access bypass and
-  Password leakage in URL), see SA-CORE-2009-007.
+  Password leakage in URL). See SA-CORE-2009-007.
 - Fixed a variety of small bugs.
 
 Drupal 6.12, 2009-05-13
-----------------------
-- Fixed security issues (Cross site scripting), see SA-CORE-2009-006.
+-----------------------
+- Fixed security issues (Cross site scripting). See SA-CORE-2009-006.
 - Fixed a variety of small bugs.
 
 Drupal 6.11, 2009-04-29
-----------------------
+-----------------------
 - Fixed security issues (Cross site scripting and limited information
-  disclosure), see SA-CORE-2009-005
+  disclosure). See SA-CORE-2009-005.
 - Fixed performance issues with the menu router cache, the update
   status cache and improved cache invalidation
 - Fixed a variety of small bugs.
 
 Drupal 6.10, 2009-02-25
-----------------------
+-----------------------
 - Fixed a security issue, (Local file inclusion on Windows),
-  see SA-CORE-2009-003
+  see SA-CORE-2009-003.
 - Fixed node_feed() so custom fields can show up in RSS feeds.
 - Improved PostgreSQL compatibility.
 - Fixed a variety of small bugs.
@@ -156,7 +161,7 @@ Drupal 6.10, 2009-02-25
 Drupal 6.9, 2009-01-14
 ----------------------
 - Fixed security issues, (Access Bypass, Validation Bypass and Hardening
-  against SQL injection), see SA-CORE-2009-001
+  against SQL injection). See SA-CORE-2009-001.
 - Made HTTP request checking more robust and informative.
 - Fixed HTTP_HOST checking to work again with HTTP 1.0 clients and
   basic shell scripts.
@@ -169,14 +174,16 @@ Drupal 6.8, 2008-12-11
 - Removed a previous change incompatible with PHP 5.1.x and lower.
 
 Drupal 6.7, 2008-12-10
-----------------------
-- Fixed security issues, (Cross site request forgery and Cross site scripting), see SA-2008-073
+-----------------------
+- Fixed security issues, (Cross site request forgery and Cross site
+  scripting), see SA-2008-073.
 - Updated robots.txt and .htaccess to match current file use.
 - Fixed a variety of small bugs.
 
 Drupal 6.6, 2008-10-22
 ----------------------
-- Fixed security issues, (File inclusion, Cross site scripting), see SA-2008-067
+- Fixed security issues, (File inclusion, Cross site scripting), See
+  SA-2008-067.
 - Fixed a variety of small bugs.
 
 Drupal 6.5, 2008-10-08
@@ -321,32 +328,33 @@ Drupal 6.0, 2008-02-13
 Drupal 5.23, 2010-08-11
 -----------------------
 - Fixed security issues (File download access bypass, Comment unpublishing
-  bypass), see SA-CORE-2010-002.
+  bypass). See SA-CORE-2010-002.
 
 Drupal 5.22, 2010-03-03
 -----------------------
 - Fixed security issues (Open redirection, Locale module cross site scripting,
-  Blocked user session regeneration), see SA-CORE-2010-001.
+  Blocked user session regeneration). See SA-CORE-2010-001.
 
 Drupal 5.21, 2009-12-16
 -----------------------
-- Fixed a security issue (Cross site scripting), see SA-CORE-2009-009.
+- Fixed a security issue (Cross site scripting). See SA-CORE-2009-009.
 - Fixed a variety of small bugs.
 
 Drupal 5.20, 2009-09-16
 -----------------------
 - Avoid security problems resulting from writing Drupal 6-style menu declarations.
-- Fixed security issues (session fixation), see SA-CORE-2009-008.
+- Fixed security issues (session fixation). See SA-CORE-2009-008.
 - Fixed a variety of small bugs.
 
 Drupal 5.19, 2009-07-01
 -----------------------
-- Fixed security issues (Cross site scripting and Password leakage in URL), see SA-CORE-2009-007.
+- Fixed security issues (Cross site scripting and Password leakage in URL).
+  See SA-CORE-2009-007.
 - Fixed a variety of small bugs.
 
 Drupal 5.18, 2009-05-13
 ----------------------
-- Fixed security issues (Cross site scripting), see SA-CORE-2009-006.
+- Fixed security issues (Cross site scripting). See SA-CORE-2009-006.
 - Fixed a variety of small bugs.
 
 Drupal 5.17, 2009-04-29
@@ -356,12 +364,14 @@ Drupal 5.17, 2009-04-29
 
 Drupal 5.16, 2009-02-25
 -----------------------
-- Fixed a security issue, (Local file inclusion on Windows), see SA-CORE-2009-004.
+- Fixed a security issue, (Local file inclusion on Windows). See
+  SA-CORE-2009-004.
 - Fixed a variety of small bugs.
 
 Drupal 5.15, 2009-01-14
 ----------------------
-- Fixed security issues, (Hardening against SQL injection), see SA-CORE-2009-001
+- Fixed security issues, (Hardening against SQL injection). See
+  SA-CORE-2009-001.
 - Fixed HTTP_HOST checking to work again with HTTP 1.0 clients and
   basic shell scripts.
 - Fixed a variety of small bugs.
@@ -378,7 +388,7 @@ Drupal 5.13, 2008-12-10
 
 Drupal 5.12, 2008-10-22
 -----------------------
-- fixed security issues, (File inclusion), see SA-2008-067
+- fixed security issues, (File inclusion), see SA-2008-067.
 
 Drupal 5.11, 2008-10-08
 -----------------------

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -797,6 +797,10 @@ function drupal_load($type, $name) {
  * Note: When sending a Content-Type header, always include a 'charset' type,
  * too. This is necessary to avoid security bugs (e.g. UTF-7 XSS).
  *
+ * Note: No special sanitizing needs to be done to headers. However if a header
+ * value contains a line break, a PHP warning will be thrown and the header
+ * will not be set.
+ *
  * @param $name
  *   The HTTP header name, or a status code followed by a reason phrase, e.g.
  *   "404 Not Found".
@@ -811,6 +815,20 @@ function drupal_set_header($name = NULL, $value = NULL, $append = FALSE) {
 
   if (!isset($name)) {
     return $headers;
+  }
+
+  // Protect against header injection attacks if PHP is too old to do that.
+  // See https://www.drupal.org/SA-CORE-2016-001,
+  // https://www.drupal.org/drupal-6.38-release-notes, and
+  // https://github.com/pressflow/6/pull/101.
+  if (version_compare(PHP_VERSION, '5.1.2', '<')) {
+    foreach (array($name, $value) as $part) {
+      if (strpos($part, "\n") !== FALSE || strpos($part, "\r") !== FALSE) {
+        // Use the same warning message that newer versions of PHP use.
+        trigger_error('Header may not contain more than a single header, new line detected', E_USER_WARNING);
+        return;
+      }
+    }
   }
 
   // Support the Drupal 6 header API
@@ -835,32 +853,17 @@ function drupal_set_header($name = NULL, $value = NULL, $append = FALSE) {
   }
   _drupal_set_preferred_header_name($name);
 
-  // Protect against header injection attacks if PHP is too old to do that.
-  // See https://www.drupal.org/SA-CORE-2016-001, and
-  // https://www.drupal.org/drupal-6.38-release-notes
-  if (version_compare(PHP_VERSION, '5.1.2', '<') &&
-    (
-      (strpos($name_lower, "\n") !== FALSE || strpos($name_lower, "\r") !== FALSE) ||
-      (strpos($value, "\n") !== FALSE || strpos($value, "\r") !== FALSE)
-    )
-  ) {
-    // Use the same warning message that newer versions of PHP use.
-    trigger_error('Header may not contain more than a single header, new line detected', E_USER_WARNING);
+  if (!isset($value)) {
+    $headers[$name_lower] = FALSE;
+  }
+  elseif (isset($headers[$name_lower]) && $append) {
+    // Multiple headers with identical names may be combined using comma (RFC
+    // 2616, section 4.2).
+    $headers[$name_lower] .= ',' . $value;
   }
   else {
-    if (!isset($value)) {
-      $headers[$name_lower] = FALSE;
-    }
-    elseif (isset($headers[$name_lower]) && $append) {
-      // Multiple headers with identical names may be combined using comma (RFC
-      // 2616, section 4.2).
-      $headers[$name_lower] .= ',' . $value;
-    }
-    else {
-      $headers[$name_lower] = $value;
-    }
+    $headers[$name_lower] = $value;
   }
-
   drupal_send_headers(array($name => $headers[$name_lower]), TRUE);
 }
 

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -587,8 +587,8 @@ function variable_init($conf = array(), $regenerate = FALSE, $recursion_depth = 
       // Wait for another request that is already doing this work.
       lock_wait('variable_cache_regenerate');
 
-      // Run the function again. Try a limited number of times to avoid 
-      // infinite recursion if the database connection is invalid for  
+      // Run the function again. Try a limited number of times to avoid
+      // infinite recursion if the database connection is invalid for
       // some reason, e.g., mysqld restart, loss of network, etc.
       $recursion_depth++;
       if ($recursion_depth < 50) {
@@ -660,7 +660,7 @@ function variable_set($name, $value) {
   if (is_string($db_prefix) && strpos($db_prefix, 'simpletest') === 0) {
     cache_clear_all('variables', 'cache');
   }
-  
+
   variable_cache_rebuild();
 }
 
@@ -689,7 +689,7 @@ function variable_del($name) {
   if (is_string($db_prefix) && strpos($db_prefix, 'simpletest') === 0) {
     cache_clear_all('variables', 'cache');
   }
-  
+
   variable_cache_rebuild();
 }
 
@@ -812,7 +812,7 @@ function drupal_set_header($name = NULL, $value = NULL, $append = FALSE) {
   if (!isset($name)) {
     return $headers;
   }
-  
+
   // Support the Drupal 6 header API
   if (!isset($value)) {
     if (strpos($name, ':') !== FALSE) {
@@ -835,17 +835,32 @@ function drupal_set_header($name = NULL, $value = NULL, $append = FALSE) {
   }
   _drupal_set_preferred_header_name($name);
 
-  if (!isset($value)) {
-    $headers[$name_lower] = FALSE;
-  }
-  elseif (isset($headers[$name_lower]) && $append) {
-    // Multiple headers with identical names may be combined using comma (RFC
-    // 2616, section 4.2).
-    $headers[$name_lower] .= ',' . $value;
+  // Protect against header injection attacks if PHP is too old to do that.
+  // See https://www.drupal.org/SA-CORE-2016-001, and
+  // https://www.drupal.org/drupal-6.38-release-notes
+  if (version_compare(PHP_VERSION, '5.1.2', '<') &&
+    (
+      (strpos($name_lower, "\n") !== FALSE || strpos($name_lower, "\r") !== FALSE) ||
+      (strpos($value, "\n") !== FALSE || strpos($value, "\r") !== FALSE)
+    )
+  ) {
+    // Use the same warning message that newer versions of PHP use.
+    trigger_error('Header may not contain more than a single header, new line detected', E_USER_WARNING);
   }
   else {
-    $headers[$name_lower] = $value;
+    if (!isset($value)) {
+      $headers[$name_lower] = FALSE;
+    }
+    elseif (isset($headers[$name_lower]) && $append) {
+      // Multiple headers with identical names may be combined using comma (RFC
+      // 2616, section 4.2).
+      $headers[$name_lower] .= ',' . $value;
+    }
+    else {
+      $headers[$name_lower] = $value;
+    }
   }
+
   drupal_send_headers(array($name => $headers[$name_lower]), TRUE);
 }
 
@@ -1234,6 +1249,8 @@ function request_uri() {
  * @param $type
  *   The category to which this message belongs. Can be any string, but the
  *   general practice is to use the name of the module calling watchdog().
+ *   The $type parameter is limited to 16 characters; anything longer is
+ *   truncated.
  * @param $message
  *   The message to store in the log. See t() for documentation
  *   on how $message and $variables interact. Keep $message
@@ -1243,8 +1260,16 @@ function request_uri() {
  *   NULL if message is already translated or not possible to
  *   translate.
  * @param $severity
- *   The severity of the message, as per RFC 3164. Possible values are
- *   WATCHDOG_ERROR, WATCHDOG_WARNING, etc.
+ *   The severity of the message; one of the following values as defined in
+ *   @link http://www.faqs.org/rfcs/rfc3164.html RFC 3164: @endlink
+ *   - WATCHDOG_EMERGENCY: Emergency, system is unusable.
+ *   - WATCHDOG_ALERT: Alert, action must be taken immediately.
+ *   - WATCHDOG_CRITICAL: Critical conditions.
+ *   - WATCHDOG_ERROR: Error conditions.
+ *   - WATCHDOG_WARNING: Warning conditions.
+ *   - WATCHDOG_NOTICE: (default) Normal but significant conditions.
+ *   - WATCHDOG_INFO: Informational messages.
+ *   - WATCHDOG_DEBUG: Debug-level messages.
  * @param $link
  *   A link to associate with the message.
  *
@@ -1430,7 +1455,7 @@ function drupal_bootstrap($phase = NULL) {
       _drupal_bootstrap($current_phase);
     }
   }
-  
+
   return $phase_index;
 }
 
@@ -1490,7 +1515,7 @@ function _drupal_bootstrap($phase) {
       // those using APC or memcached.
       require_once variable_get('lock_inc', './includes/lock.inc');
       lock_init();
-      
+
       // Detect if an installation is present.
       detect_installation_or_run_installer();
 
@@ -1524,8 +1549,6 @@ function _drupal_bootstrap($phase) {
       // because menu_path_is_external() requires the variable system to be
       // available.
       if (isset($_GET['destination']) || isset($_REQUEST['destination']) || isset($_REQUEST['edit']['destination'])) {
-        require_once './includes/menu.inc';
-        drupal_load('module', 'filter');
         // If the destination is an external URL, remove it.
         if (isset($_GET['destination']) && menu_path_is_external($_GET['destination'])) {
           unset($_GET['destination']);
@@ -1569,11 +1592,11 @@ function _drupal_bootstrap($phase) {
         // We are done.
         exit;
       }
-  
+
       if (!$cache && drupal_page_is_cacheable() && $cache_mode != CACHE_EXTERNAL) {
         header('X-Drupal-Cache: MISS');
       }
-      
+
       // If using an external cache and the page is cacheable, set headers.
       if ($cache_mode == CACHE_EXTERNAL && drupal_page_is_cacheable()) {
         drupal_page_cache_header_external();
@@ -1714,17 +1737,17 @@ function ip_address() {
 
   if (!isset($ip_address)) {
     $ip_address = $_SERVER['REMOTE_ADDR'];
-    
+
     // Only use parts of the X-Forwarded-For (XFF) header that have followed a trusted route.
     // Specifically, identify the leftmost IP address in the XFF header that is not one of ours.
     // An XFF header is: X-Forwarded-For: client1, proxy1, proxy2
     if (isset($_SERVER['HTTP_' . variable_get('x_forwarded_for_header', 'X_FORWARDED_FOR')]) && variable_get('reverse_proxy', 0)) {
       // Load trusted reverse proxy server IPs.
       $reverse_proxy_addresses = variable_get('reverse_proxy_addresses', array());
-      
+
       // Turn XFF header into an array.
       $forwarded = explode(',', $_SERVER['HTTP_' . variable_get('x_forwarded_for_header', 'X_FORWARDED_FOR')]);
-      
+
       // Trim the forwarded IPs; they may have been delimited by commas and spaces.
       $forwarded = array_map('trim', $forwarded);
 
@@ -1733,7 +1756,7 @@ function ip_address() {
 
       // Eliminate all trusted IPs.
       $untrusted = array_diff($forwarded, $reverse_proxy_addresses);
-      
+
       // The right-most IP is the most specific we can trust.
       $ip_address = array_pop($untrusted);
     }
@@ -1747,9 +1770,9 @@ function ip_address() {
  */
 function drupal_session_initialize() {
   global $user;
-   
+
   session_set_save_handler('sess_open', 'sess_close', 'sess_read', 'sess_write', 'sess_destroy_sid', 'sess_gc');
- 
+
   // Use !empty() in the following check to ensure that blank session IDs
   // are not valid.
   if (!empty($_COOKIE[session_name()])) {
@@ -1813,7 +1836,7 @@ function drupal_session_commit() {
 
 /**
  * Return whether a session has been started.
- */  
+ */
 function drupal_session_started($set = NULL) {
   static $session_started = FALSE;
   if (isset($set)) {
@@ -1923,7 +1946,7 @@ function drupal_generate_test_ua($prefix) {
     // check the HMAC before the database is initialized. filectime()
     // and fileinode() are not easily determined from remote.
 //    $filepath = DRUPAL_ROOT . '/includes/bootstrap.inc';
-    $filepath = './includes/bootstrap.inc';                
+    $filepath = './includes/bootstrap.inc';
 //    $key = sha1(serialize($databases) . filectime($filepath) . fileinode($filepath), TRUE);
     $key = sha1(serialize($db_url) . filectime($filepath) . fileinode($filepath), TRUE);
   }
@@ -2109,4 +2132,75 @@ function drupal_hmac_base64($data, $key) {
   $hmac = base64_encode(pack("H*", drupal_hash_hmac_sha1((string) $data, (string) $key)));
   // Modify the hmac so it's safe to use in URLs.
   return strtr($hmac, array('+' => '-', '/' => '_', '=' => ''));
+}
+
+/**
+ * Returns TRUE if a path is external (e.g. http://example.com).
+ *
+ * May be used early in bootstrap.
+ */
+function menu_path_is_external($path) {
+  // Avoid calling filter_xss_bad_protocol() if there is any slash (/),
+  // hash (#) or question_mark (?) before the colon (:) occurrence - if any - as
+  // this would clearly mean it is not a URL. If the path starts with 2 slashes
+  // then it is always considered an external URL without an explicit protocol
+  // part. Leading control characters may be ignored or mishandled by browsers,
+  // so assume such a path may lead to an external location. The range matches
+  // all UTF-8 control characters, class Cc.
+  $colonpos = strpos($path, ':');
+  // Some browsers treat \ as / so normalize to forward slashes.
+  $path = str_replace('\\', '/', $path);
+  return (strpos($path, '//') === 0) || (preg_match('/^[\x00-\x1F\x7F-\x9F]/u', $path) !== 0)
+  || ($colonpos !== FALSE
+    && !preg_match('![/?#]!', substr($path, 0, $colonpos))
+    && filter_xss_bad_protocol($path, FALSE) == check_plain($path));
+}
+
+/**
+ * Processes an HTML attribute value and ensures it does not contain an URL
+ * with a disallowed protocol (e.g. javascript:)
+ *
+ * May be used early in bootstrap.
+ *
+ * @param $string
+ *   The string with the attribute value.
+ * @param $decode
+ *   Whether to decode entities in the $string. Set to FALSE if the $string
+ *   is in plain text, TRUE otherwise. Defaults to TRUE.
+ * @return
+ *   Cleaned up and HTML-escaped version of $string.
+ */
+function filter_xss_bad_protocol($string, $decode = TRUE) {
+  static $allowed_protocols;
+  if (!isset($allowed_protocols)) {
+    $allowed_protocols = array_flip(variable_get('filter_allowed_protocols', array('http', 'https', 'ftp', 'news', 'nntp', 'tel', 'telnet', 'mailto', 'irc', 'ssh', 'sftp', 'webcal', 'rtsp')));
+  }
+
+  // Get the plain text representation of the attribute value (i.e. its meaning).
+  if ($decode) {
+    $string = decode_entities($string);
+  }
+
+  // Iteratively remove any invalid protocol found.
+
+  do {
+    $before = $string;
+    $colonpos = strpos($string, ':');
+    if ($colonpos > 0) {
+      // We found a colon, possibly a protocol. Verify.
+      $protocol = substr($string, 0, $colonpos);
+      // If a colon is preceded by a slash, question mark or hash, it cannot
+      // possibly be part of the URL scheme. This must be a relative URL,
+      // which inherits the (safe) protocol of the base document.
+      if (preg_match('![/?#]!', $protocol)) {
+        break;
+      }
+      // Per RFC2616, section 3.2.3 (URI Comparison) scheme comparison must be case-insensitive
+      // Check if this is a disallowed protocol.
+      if (!isset($allowed_protocols[strtolower($protocol)])) {
+        $string = substr($string, $colonpos + 1);
+      }
+    }
+  } while ($before != $string);
+  return check_plain($string);
 }

--- a/includes/common.inc
+++ b/includes/common.inc
@@ -297,17 +297,18 @@ function drupal_get_destination() {
  * @param $fragment
  *   (optional) A destination fragment identifier (named anchor).
  * @param $http_response_code
- *   (optional) The HTTP status code to use for the redirection, defaults to
- *   302. Valid values for an actual "goto" as per RFC 2616 section 10.3 are:
- *   - 301 Moved Permanently (the recommended value for most redirects)
- *   - 302 Found (default in Drupal and PHP, sometimes used for spamming search
- *         engines)
- *   - 303 See Other
- *   - 304 Not Modified
- *   - 305 Use Proxy
- *   - 307 Temporary Redirect (alternative to "503 Site Down for Maintenance")
- *   Note: Other values are defined by RFC 2616, but are rarely used and poorly
- *   supported.
+ *   (optional) The HTTP status code to use for the redirection, defaults to 302.
+ *   The valid values for 3xx redirection status codes are defined in
+ *   @link http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3 RFC 2616 @endlink
+ *   and the
+ *   @link http://tools.ietf.org/html/draft-reschke-http-status-308-07 draft for the new HTTP status codes: @endlink
+ *   - 301: Moved Permanently (the recommended value for most redirects).
+ *   - 302: Found (default in Drupal and PHP, sometimes used for spamming search
+ *     engines).
+ *   - 303: See Other.
+ *   - 304: Not Modified.
+ *   - 305: Use Proxy.
+ *   - 307: Temporary Redirect.
  * @see drupal_get_destination()
  */
 function drupal_goto($path = '', $query = NULL, $fragment = NULL, $http_response_code = 302) {
@@ -322,14 +323,20 @@ function drupal_goto($path = '', $query = NULL, $fragment = NULL, $http_response
 
   if ($destination) {
     // Do not redirect to an absolute URL originating from user input.
-    $colonpos = strpos($destination, ':');
-    $absolute = strpos($destination, '//') === 0 || ($colonpos !== FALSE && !preg_match('![/?#]!', substr($destination, 0, $colonpos)));
-    if (!$absolute) {
-      extract(parse_url(urldecode($destination)));
+    if (!menu_path_is_external($destination)) {
+      extract(parse_url($destination));
     }
   }
 
-  $url = url($path, array('query' => $query, 'fragment' => $fragment, 'absolute' => TRUE));
+  $options = array('query' => $query, 'fragment' => $fragment, 'absolute' => TRUE);
+  // In some cases modules call drupal_goto($_GET['q']). We need to ensure that
+  // such a redirect is not to an external URL.
+  if ($path === $_GET['q'] && menu_path_is_external($path)) {
+    // Force url() to generate a non-external URL.
+    $options['external'] = FALSE;
+  }
+
+  $url = url($path, $options);
   // Remove newlines from the URL to avoid header injection attacks.
   $url = str_replace(array("\n", "\r"), '', $url);
 
@@ -1472,20 +1479,9 @@ function url($path = NULL, $options = array()) {
     'alias' => FALSE,
     'prefix' => ''
   );
-  // A duplicate of the code from menu_path_is_external() to avoid needing
-  // another function call, since performance inside url() is critical.
+
   if (!isset($options['external'])) {
-    // Return an external link if $path contains an allowed absolute URL. Avoid
-    // calling filter_xss_bad_protocol() if there is any slash (/), hash (#) or
-    // question_mark (?) before the colon (:) occurrence - if any - as this
-    // would clearly mean it is not a URL. If the path starts with 2 slashes
-    // then it is always considered an external URL without an explicit protocol
-    // part.
-    $colonpos = strpos($path, ':');
-    $options['external'] = (strpos($path, '//') === 0)
-      || ($colonpos !== FALSE
-        && !preg_match('![/?#]!', substr($path, 0, $colonpos))
-        && filter_xss_bad_protocol($path, FALSE) == check_plain($path));
+    $options['external'] = menu_path_is_external($path);
   }
 
   // May need language dependent rewriting if language.inc is present.
@@ -2765,7 +2761,7 @@ function page_set_cache() {
         'created' => $_SERVER['REQUEST_TIME'],
         'headers' => array(),
       );
-    
+
       // Restore preferred header names based on the lower-case names returned
       // by drupal_get_header().
       $header_names = _drupal_set_preferred_header_name();

--- a/includes/database.mysql-common.inc
+++ b/includes/database.mysql-common.inc
@@ -286,7 +286,7 @@ function db_drop_table(&$ret, $table) {
  *   This is most useful for creating NOT NULL columns with no default
  *   value in existing tables.
  * @param $keys_new
- *   Optional keys and indexes specification to be created on the
+ *   (optional) Keys and indexes specification to be created on the
  *   table along with adding the field. The format is the same as a
  *   table specification but without the 'fields' element.  If you are
  *   adding a type 'serial' field, you MUST specify at least one key
@@ -515,7 +515,7 @@ function db_drop_index(&$ret, $table, $name) {
  * @param $spec
  *   The field specification for the new field.
  * @param $keys_new
- *   Optional keys and indexes specification to be created on the
+ *   (optional) Keys and indexes specification to be created on the
  *   table along with changing the field. The format is the same as a
  *   table specification but without the 'fields' element.
  */

--- a/includes/database.pgsql.inc
+++ b/includes/database.pgsql.inc
@@ -715,7 +715,7 @@ function db_drop_table(&$ret, $table) {
  *   This is most useful for creating NOT NULL columns with no default
  *   value in existing tables.
  * @param $new_keys
- *   Optional keys and indexes specification to be created on the
+ *   (optional) Keys and indexes specification to be created on the
  *   table along with adding the field. The format is the same as a
  *   table specification but without the 'fields' element.  If you are
  *   adding a type 'serial' field, you MUST specify at least one key
@@ -945,7 +945,7 @@ function db_drop_index(&$ret, $table, $name) {
  * @param $spec
  *   The field specification for the new field.
  * @param $new_keys
- *   Optional keys and indexes specification to be created on the
+ *   (optional) Keys and indexes specification to be created on the
  *   table along with changing the field. The format is the same as a
  *   table specification but without the 'fields' element.
  */

--- a/includes/file.inc
+++ b/includes/file.inc
@@ -633,7 +633,7 @@ function file_save_upload($source, $validators = array(), $dest = FALSE, $replac
   global $user;
   static $upload_cache;
 
-  // Add in our check of the the file name length.
+  // Add our check of the file name length.
   $validators['file_validate_name_length'] = array();
 
   // Return cached objects without processing since the file will have

--- a/includes/form.inc
+++ b/includes/form.inc
@@ -1066,9 +1066,16 @@ function _form_builder_handle_input_element($form_id, &$form, &$form_state, $com
     $form['#attributes']['disabled'] = 'disabled';
   }
 
+  // With JavaScript or other easy hacking, input can be submitted even for
+  // elements with #access=FALSE. For security, these must not be processed.
+  // For pages with multiple forms, ensure that input is only processed for the
+  // submitted form. drupal_execute() may bypass these checks and be treated as
+  // a high privilege user submitting a single form.
+  $process_input = $form['#programmed'] || ((!isset($form['#access']) || $form['#access']) && isset($form['#post']) && (isset($form['#post']['form_id']) && $form['#post']['form_id'] == $form_id));
+
   if (!isset($form['#value']) && !array_key_exists('#value', $form)) {
     $function = !empty($form['#value_callback']) ? $form['#value_callback'] : 'form_type_'. $form['#type'] .'_value';
-    if (($form['#programmed']) || ((!isset($form['#access']) || $form['#access']) && isset($form['#post']) && (isset($form['#post']['form_id']) && $form['#post']['form_id'] == $form_id))) {
+    if ($process_input) {
       $edit = $form['#post'];
       foreach ($form['#parents'] as $parent) {
         $edit = isset($edit[$parent]) ? $edit[$parent] : NULL;
@@ -1113,7 +1120,7 @@ function _form_builder_handle_input_element($form_id, &$form, &$form_state, $com
   // We compare the incoming values with the buttons defined in the form,
   // and flag the one that matches. We have to do some funky tricks to
   // deal with Internet Explorer's handling of single-button forms, though.
-  if (!empty($form['#post']) && isset($form['#executes_submit_callback'])) {
+  if ($process_input && !empty($form['#post']) && isset($form['#executes_submit_callback'])) {
     // First, accumulate a collection of buttons, divided into two bins:
     // those that execute full submit callbacks and those that only validate.
     $button_type = $form['#executes_submit_callback'] ? 'submit' : 'button';

--- a/includes/menu.inc
+++ b/includes/menu.inc
@@ -2483,22 +2483,6 @@ function _menu_router_build($callbacks) {
 }
 
 /**
- * Returns TRUE if a path is external (e.g. http://example.com).
- */
-function menu_path_is_external($path) {
-  // Avoid calling filter_xss_bad_protocol() if there is any slash (/),
-  // hash (#) or question_mark (?) before the colon (:) occurrence - if any - as
-  // this would clearly mean it is not a URL. If the path starts with 2 slashes
-  // then it is always considered an external URL without an explicit protocol
-  // part.
-  $colonpos = strpos($path, ':');
-  return (strpos($path, '//') === 0)
-    || ($colonpos !== FALSE
-      && !preg_match('![/?#]!', substr($path, 0, $colonpos))
-      && filter_xss_bad_protocol($path, FALSE) == check_plain($path));
-}
-
-/**
  * Checks whether the site is off-line for maintenance.
  *
  * This function will log the current user out and redirect to front page

--- a/includes/xmlrpcs.inc
+++ b/includes/xmlrpcs.inc
@@ -213,6 +213,10 @@ function xmlrpc_server_call($xmlrpc_server, $methodname, $args) {
 
 function xmlrpc_server_multicall($methodcalls) {
   // See http://www.xmlrpc.com/discuss/msgReader$1208
+  // To avoid multicall expansion attacks, limit the number of duplicate method
+  // calls allowed with a default of 1. Set to -1 for unlimited.
+  $duplicate_method_limit = variable_get('xmlrpc_multicall_duplicate_method_limit', 1);
+  $method_count = array();
   $return = array();
   $xmlrpc_server = xmlrpc_server_get();
   foreach ($methodcalls as $call) {
@@ -222,9 +226,13 @@ function xmlrpc_server_multicall($methodcalls) {
       $ok = FALSE;
     }
     $method = $call['methodName'];
+    $method_count[$method] = isset($method_count[$method]) ? $method_count[$method] + 1 : 1;
     $params = $call['params'];
     if ($method == 'system.multicall') {
       $result = xmlrpc_error(-32600, t('Recursive calls to system.multicall are forbidden.'));
+    }
+    elseif ($duplicate_method_limit > 0 && $method_count[$method] > $duplicate_method_limit) {
+      $result = xmlrpc_error(-156579, t('Too many duplicate method calls in system.multicall.'));
     }
     elseif ($ok) {
       $result = xmlrpc_server_call($xmlrpc_server, $method, $params);

--- a/misc/tableselect.js
+++ b/misc/tableselect.js
@@ -56,7 +56,7 @@ Drupal.tableSelect = function() {
 };
 
 Drupal.tableSelectRange = function(from, to, state) {
-  // We determine the looping mode based on the the order of from and to.
+  // We determine the looping mode based on the order of from and to.
   var mode = from.rowIndex > to.rowIndex ? 'previousSibling' : 'nextSibling';
 
   // Traverse through the sibling nodes.

--- a/modules/filter/filter.module
+++ b/modules/filter/filter.module
@@ -1204,52 +1204,5 @@ function _filter_xss_attributes($attr) {
 }
 
 /**
- * Processes an HTML attribute value and ensures it does not contain an URL
- * with a disallowed protocol (e.g. javascript:)
- *
- * @param $string
- *   The string with the attribute value.
- * @param $decode
- *   Whether to decode entities in the $string. Set to FALSE if the $string
- *   is in plain text, TRUE otherwise. Defaults to TRUE.
- * @return
- *   Cleaned up and HTML-escaped version of $string.
- */
-function filter_xss_bad_protocol($string, $decode = TRUE) {
-  static $allowed_protocols;
-  if (!isset($allowed_protocols)) {
-    $allowed_protocols = array_flip(variable_get('filter_allowed_protocols', array('http', 'https', 'ftp', 'news', 'nntp', 'tel', 'telnet', 'mailto', 'irc', 'ssh', 'sftp', 'webcal', 'rtsp')));
-  }
-
-  // Get the plain text representation of the attribute value (i.e. its meaning).
-  if ($decode) {
-    $string = decode_entities($string);
-  }
-
-  // Iteratively remove any invalid protocol found.
-
-  do {
-    $before = $string;
-    $colonpos = strpos($string, ':');
-    if ($colonpos > 0) {
-      // We found a colon, possibly a protocol. Verify.
-      $protocol = substr($string, 0, $colonpos);
-      // If a colon is preceded by a slash, question mark or hash, it cannot
-      // possibly be part of the URL scheme. This must be a relative URL,
-      // which inherits the (safe) protocol of the base document.
-      if (preg_match('![/?#]!', $protocol)) {
-        break;
-      }
-      // Per RFC2616, section 3.2.3 (URI Comparison) scheme comparison must be case-insensitive
-      // Check if this is a disallowed protocol.
-      if (!isset($allowed_protocols[strtolower($protocol)])) {
-        $string = substr($string, $colonpos + 1);
-      }
-    }
-  } while ($before != $string);
-  return check_plain($string);
-}
-
-/**
  * @} End of "Standard filters".
  */

--- a/modules/system/system.admin.inc
+++ b/modules/system/system.admin.inc
@@ -1499,7 +1499,8 @@ function system_rss_feeds_settings() {
  */
 function system_date_time_settings() {
   drupal_add_js(drupal_get_path('module', 'system') .'/system.js', 'module');
-  drupal_add_js(array('dateTime' => array('lookup' => url('admin/settings/date-time/lookup'))), 'setting');
+  $ajax_path = 'admin/settings/date-time/lookup';
+  drupal_add_js(array('dateTime' => array('lookup' => url($ajax_path, array('query' => array('token' => drupal_get_token($ajax_path)))))), 'setting');
 
   // Date settings:
   $zones = _system_zonelist();
@@ -1658,6 +1659,11 @@ function system_date_time_settings_submit($form, &$form_state) {
  * Return the date for a given format string via Ajax.
  */
 function system_date_time_lookup() {
+  // This callback is protected with a CSRF token because user input from the
+  // query string is reflected in the output.
+  if (!isset($_GET['token']) || !drupal_valid_token($_GET['token'], 'admin/settings/date-time/lookup')) {
+    return MENU_ACCESS_DENIED;
+  }
   $result = format_date(time(), 'custom', $_GET['format']);
   drupal_json($result);
 }

--- a/modules/system/system.install
+++ b/modules/system/system.install
@@ -1071,7 +1071,7 @@ function system_schema() {
         'default' => 0),
       'session' => array(
         'description' => 'The serialized contents of $_SESSION, an array of name/value pairs that persists across page requests by this session ID. Drupal loads $_SESSION from here at the start of each request and saves it at the end.',
-        'type' => 'text',
+        'type' => 'blob',
         'not null' => FALSE,
         'size' => 'big')
       ),
@@ -2747,6 +2747,15 @@ function system_update_6055() {
   db_drop_unique_key($ret, 'url_alias', 'dst_language');
   db_add_index($ret, 'url_alias', 'src_language_pid', array('src', 'language', 'pid'));
   db_add_unique_key($ret, 'url_alias', 'dst_language_pid', array('dst', 'language', 'pid'));
+  return $ret;
+}
+
+/**
+ * Convert {session} data storage to blob.
+ */
+function system_update_6056() {
+  $ret = array();
+  db_change_field($ret, 'sessions', 'session', 'session', array('type' => 'blob', 'not null' => FALSE, 'size' => 'big'));
   return $ret;
 }
 

--- a/modules/system/system.js
+++ b/modules/system/system.js
@@ -101,7 +101,7 @@ Drupal.behaviors.dateTime = function(context) {
   // Attach keyup handler to custom format inputs.
   $('input.custom-format:not(.date-time-processed)', context).addClass('date-time-processed').keyup(function() {
     var input = $(this);
-    var url = Drupal.settings.dateTime.lookup +(Drupal.settings.dateTime.lookup.match(/\?q=/) ? "&format=" : "?format=") + encodeURIComponent(input.val());
+    var url = Drupal.settings.dateTime.lookup +(Drupal.settings.dateTime.lookup.match(/\?/) ? "&format=" : "?format=") + encodeURIComponent(input.val());
     $.getJSON(url, function(data) {
       $("div.description span", input.parent()).html(data);
     });

--- a/modules/system/system.module
+++ b/modules/system/system.module
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '6.37');
+define('VERSION', '6.38');
 
 /**
  * Core API compatibility.

--- a/modules/user/user.module
+++ b/modules/user/user.module
@@ -670,8 +670,15 @@ function user_user($type, &$edit, &$account, $category = NULL) {
     return _user_edit_validate((isset($account->uid) ? $account->uid : FALSE), $edit);
   }
 
-  if ($type == 'submit' && $category == 'account') {
-    return _user_edit_submit((isset($account->uid) ? $account->uid : FALSE), $edit);
+  if ($type == 'submit') {
+    if ($category == 'account') {
+      return _user_edit_submit((isset($account->uid) ? $account->uid : FALSE), $edit);
+    }
+    elseif (isset($edit['roles'])) {
+      // Filter out roles with empty values to avoid granting extra roles when
+      // processing custom form submissions.
+      $edit['roles'] = array_filter($edit['roles']);
+    }
   }
 
   if ($type == 'categories') {
@@ -681,7 +688,7 @@ function user_user($type, &$edit, &$account, $category = NULL) {
 
 function user_login_block() {
   $form = array(
-    '#action' => url($_GET['q'], array('query' => drupal_get_destination())),
+    '#action' => url($_GET['q'], array('query' => drupal_get_destination(), 'external' => FALSE)),
     '#id' => 'user-login-form',
     '#validate' => user_login_default_validators(),
     '#submit' => array('user_login_submit'),

--- a/robots.txt
+++ b/robots.txt
@@ -11,10 +11,10 @@
 # Ignored: http://example.com/site/robots.txt
 #
 # For more information about the robots.txt standard, see:
-# http://www.robotstxt.org/wc/robots.html
+# http://www.robotstxt.org/robotstxt.html
 #
 # For syntax checking, see:
-# http://www.sxw.org.uk/computing/robots/check.html
+# http://www.frobee.com/robots-txt-check
 
 User-agent: *
 Crawl-delay: 10


### PR DESCRIPTION
https://www.drupal.org/SA-CORE-2016-001

Note there were conflicts in `CHANGELOG.txt` and `includes/common.inc`,
that were easy to merge, however, one conflict in drupal_set_header()
(in modules/system/system.module) was not, and I had to write custom
code for it.

Essentially drupal_set_header() had been moved from
`includes/common.inc` into `includes/bootstrap.inc`, and the two
functions had diverged somewhat since the move. Looking at the Pressflow
code, it appeared to be vulnerable to the same attack that was patched
in Drupal core 6.38 (HTTP header injection using line breaks on PHP
versions earlier than 5.1.2).

In Drupal core, the patch was:

```
diff --git a/includes/common.inc b/includes/common.inc
index 19798ba..9a28c06 100644
--- a/includes/common.inc
+++ b/includes/common.inc
@@ -150,8 +154,15 @@ function drupal_set_header($header = NULL) {
   static $stored_headers = array();

   if (strlen($header)) {
-    header($header);
-    $stored_headers[] = $header;
+    // Protect against header injection attacks if PHP is too old to do that.
+    if (version_compare(PHP_VERSION, '5.1.2', '<') && (strpos($header, "\n") !== FALSE || strpos($header, "\r") !== FALSE)) {
+      // Use the same warning message that newer versions of PHP use.
+      trigger_error('Header may not contain more than a single header, new line detected', E_USER_WARNING);
+    }
+    else {
+      header($header);
+      $stored_headers[] = $header;
+    }
   }
   return implode("\n", $stored_headers);
 }
```

- see http://cgit.drupalcode.org/drupal/commit/?h=6.38&id=18f1c229fcb87b1a1f94fcb1f0785ba3d40fc402

Pressflow constructs headers differently though: it constructs a
`$headers` array, where it maps `$name_lower` (i.e.: the properly-cased
HTTP header name) to `$value` (i.e.: the value of that header). It then
passes the `$headers` array to `drupal_send_headers()`.

So in this patch, I added the check around the code which modifies the
`$headers` array:

```
diff --git a/includes/bootstrap.inc b/includes/bootstrap.inc
index 58b74a6..e50053b 100644
--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -835,17 +835,32 @@ function drupal_set_header($name = NULL, $value = NULL, $append = FALSE) {
   }
   _drupal_set_preferred_header_name($name);

-  if (!isset($value)) {
-    $headers[$name_lower] = FALSE;
-  }
-  elseif (isset($headers[$name_lower]) && $append) {
-    // Multiple headers with identical names may be combined using comma (RFC
-    // 2616, section 4.2).
-    $headers[$name_lower] .= ',' . $value;
+  // Protect against header injection attacks if PHP is too old to do that.
+  // See https://www.drupal.org/SA-CORE-2016-001, and
+  // https://www.drupal.org/drupal-6.38-release-notes
+  if (version_compare(PHP_VERSION, '5.1.2', '<') &&
+    (
+      (strpos($name_lower, "\n") !== FALSE || strpos($name_lower, "\r") !== FALSE) ||
+      (strpos($value, "\n") !== FALSE || strpos($value, "\r") !== FALSE)
+    )
+  ) {
+    // Use the same warning message that newer versions of PHP use.
+    trigger_error('Header may not contain more than a single header, new line detected', E_USER_WARNING);
   }
   else {
-    $headers[$name_lower] = $value;
+    if (!isset($value)) {
+      $headers[$name_lower] = FALSE;
+    }
+    elseif (isset($headers[$name_lower]) && $append) {
+      // Multiple headers with identical names may be combined using comma (RFC
+      // 2616, section 4.2).
+      $headers[$name_lower] .= ',' . $value;
+    }
+    else {
+      $headers[$name_lower] = $value;
+    }
   }
+
   drupal_send_headers(array($name => $headers[$name_lower]), TRUE);
 }
```

I would very much appreciate some code review and testing. It's been a
while since I've worked with Drupal 6 code and Drupal 6 sites!