### PR TITLE
SA-CORE-2016-003

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -76,6 +76,12 @@ DirectoryIndex index.php
   </FilesMatch>
 </IfModule>
 
+# Disable Proxy header, since it's an attack vector. See https://www.drupal.org/SA-CORE-2016-003
+<IfModule mod_headers.c>
+  RequestHeader unset Proxy
+</IfModule>
+
+
 # Various rewrite rules.
 <IfModule mod_rewrite.c>
   RewriteEngine on

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,18 @@
+Drupal 6.38-p1, 2016-08-10 - SA-CORE-2016-003
+---------------------------------------------
+
+The provided patch will mitigate possible exploits of the HTTP_PROXY
+header in Drupal 6. There are no currently known vectors of this
+exploit in Drupal 6, however, we still advise blocking the HTTP_PROXY
+header either with this patch for simple Apache installations (the
+patch includes rules in .htaccess) or via your own configuration if
+you use another webserver and/or you have disabled htaccess. You can
+read more about this issue here: https://www.drupal.org/SA-CORE-2016-003
+and here: https://httpoxy.org/
+
+Almost all site administrators will want to take the infrastructure
+actions suggested in httppoxy.org and a complete solution to this
+vulnerability.
 
 Drupal 6.38, 2016-02-24 - Final release
 ---------------------------------------

--- a/modules/system/system.module
+++ b/modules/system/system.module
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '6.38');
+define('VERSION', '6.38-p1');
 
 /**
  * Core API compatibility.


### PR DESCRIPTION
While Drupal 6 wasn't vulnerable to SA-CORE-2016-003 because it's not using guzzle. Tag1 decided to backport this fix for hardening as part of our D6LTS program.

There are a couple of things to sort out though:
- This PR updates the core version to 6.38-p1. Otherwise there's no way to differentiate between a patch and unpatched release. We didn't want to update to 6.39 because theoretically that could still exist one day
