### PR TITLE
Issue #1191290 by klausi, David_Rothstein, Fabianx: system_cron() should not run hook_flush_caches(), but use a cached version.

### DIFF
--- a/includes/module.inc
+++ b/includes/module.inc
@@ -432,6 +432,7 @@ function module_implements($hook, $sort = FALSE, $refresh = FALSE) {
 
   if ($refresh) {
     $implementations = array();
+    cache_clear_all('system_cache_tables', 'cache');
     return;
   }
 

--- a/modules/system/system.module
+++ b/modules/system/system.module
@@ -1327,8 +1327,21 @@ function system_cron() {
     }
     db_query('DELETE FROM {files} WHERE fid = %d', $file->fid);
   }
-  $core = array('cache', 'cache_block', 'cache_filter', 'cache_page', 'cache_form', 'cache_menu');
-  $cache_tables = array_merge(module_invoke_all('flush_caches'), $core);
+
+  // Delete expired cache entries.
+  // Avoid invoking hook_flush_cashes() on every cron run because some modules
+  // use this hook to perform expensive rebuilding operations (which are only
+  // designed to happen on full cache clears), rather than just returning a
+  // list of cache tables to be cleared.
+  $cache_object = cache_get('system_cache_tables');
+  if (empty($cache_object)) {
+    $core = array('cache', 'cache_block', 'cache_filter', 'cache_page', 'cache_form', 'cache_menu');
+    $cache_tables = array_merge(module_invoke_all('flush_caches'), $core);
+    cache_set('system_cache_tables', $cache_tables);
+  }
+  else {
+    $cache_tables = $cache_object->data;
+  }
   foreach ($cache_tables as $table) {
     cache_clear_all(NULL, $table);
   }


### PR DESCRIPTION
This is a straight backport of https://www.drupal.org/node/1191290.

The reason is that else e.g. features_flush_caches() runs during every _cron invocation, which can be quite slow.