### PR TITLE
Apply the changes from D6LTS 6.45

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -58,6 +58,16 @@ DirectoryIndex index.php
   php_value mbstring.encoding_translation   0
 </IfModule>
 
+# PHP 7, Apache 1 and 2.
+<IfModule mod_php7.c>
+  php_value magic_quotes_gpc                0
+  php_value register_globals                0
+  php_value session.auto_start              0
+  php_value mbstring.http_input             pass
+  php_value mbstring.http_output            pass
+  php_value mbstring.encoding_translation   0
+</IfModule>
+
 # Requires mod_expires to be enabled.
 <IfModule mod_expires.c>
   # Enable expirations.

--- a/includes/bootstrap.inc
+++ b/includes/bootstrap.inc
@@ -741,7 +741,7 @@ function drupal_page_is_cacheable($force = NULL) {
   $result = $forced_cache
     && !drupal_session_started()
     && ($_SERVER['REQUEST_METHOD'] == 'GET' || $_SERVER['REQUEST_METHOD'] == 'HEAD')
-    && !count(drupal_get_messages(NULL, FALSE))
+    && !drupal_get_messages(NULL, FALSE)
     && !drupal_is_cli();
 
   return $result;
@@ -1872,7 +1872,12 @@ function drupal_session_regenerate() {
 
   if (drupal_session_started()) {
     $old_session_id = session_id();
+    // On PHP7, sess_read($key) is being called with the new session key but not
+    // on PHP5. This failsafe stores the initial user object, which on PHP5 should
+    // be just the same, and restore it later on.
+    $account = $user;
     session_regenerate_id();
+    $user = $account;
   }
   else {
     // Start the session when it doesn't exist yet.
@@ -2354,4 +2359,31 @@ function _drupal_parse_url($url) {
     unset($options['query']['q']);
   }
   return $options;
+}
+
+// Shim for ereg() family of functions for PHP 7+ where they don't exist.
+if (!function_exists('ereg')) {
+  function ereg($pattern, $subject, &$matches = array()) {
+    return preg_match('/' . $pattern . '/', $subject, $matches);
+  }
+
+  function eregi($pattern, $subject, &$matches = array()) {
+    return preg_match('/' . $pattern . '/i', $subject, $matches);
+  }
+
+  function ereg_replace($pattern, $replacement, $string) {
+    return preg_replace('/' . $pattern . '/', $replacement, $string);
+  }
+
+  function eregi_replace($pattern, $replacement, $string) {
+    return preg_replace('/' . $pattern . '/i', $replacement, $string);
+  }
+
+  function split($pattern, $subject, $limit = -1) {
+    return preg_split('/' . $pattern . '/', $subject, $limit);
+  }
+
+  function spliti($pattern, $subject, $limit = -1) {
+    return preg_split('/' . $pattern . '/i', $subject, $limit);
+  }
 }

--- a/includes/file.inc
+++ b/includes/file.inc
@@ -236,6 +236,9 @@ SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
 <IfModule mod_php5.c>
   php_flag engine off
 </IfModule>
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>
 # PHP 4, Apache 1.
 <IfModule mod_php4.c>
   php_flag engine off

--- a/includes/form.inc
+++ b/includes/form.inc
@@ -737,7 +737,7 @@ function _form_validate($elements, &$form_state, $form_id = NULL) {
       // A simple call to empty() will not cut it here as some fields, like
       // checkboxes, can return a valid value of '0'. Instead, check the
       // length if it's a string, and the item count if it's an array.
-      if ($elements['#required'] && (!count($elements['#value']) || (is_string($elements['#value']) && strlen(trim($elements['#value'])) == 0))) {
+      if ($elements['#required'] && (is_array($elements['#value']) && !count($elements['#value']) || (is_string($elements['#value']) && strlen(trim($elements['#value'])) == 0))) {
         form_error($elements, $t('!name field is required.', array('!name' => $elements['#title'])));
       }
 
@@ -1426,6 +1426,12 @@ function form_set_value($form_item, $value, &$form_state) {
 function _form_set_value(&$form_values, $form_item, $parents, $value) {
   $parent = array_shift($parents);
   if (empty($parents)) {
+    // This makes PHP 7 have the same behavior as PHP 5 when the value is an
+    // empty string, rather than an array. This is depended on surprisingly
+    // often in Drupal 6 contrib.
+    if ($form_values === '') {
+      $form_values = array();
+    }
     $form_values[$parent] = $value;
   }
   else {

--- a/includes/install.inc
+++ b/includes/install.inc
@@ -236,6 +236,11 @@ function drupal_rewrite_settings($settings = array(), $prefix = '') {
     if ($fp && fwrite($fp, $buffer) === FALSE) {
       drupal_set_message(st('Failed to modify %settings, please verify the file permissions.', array('%settings' => $settings_file)), 'error');
     }
+    fclose($fp);
+    // Invalidate the cache of the settings file so next request read the newly modified one
+    if (function_exists('opcache_invalidate')) {
+      opcache_invalidate($settings_file, TRUE);
+    }
   }
   else {
     drupal_set_message(st('Failed to open %settings, please verify the file permissions.', array('%settings' => $default_settings)), 'error');

--- a/includes/install.mysql.inc
+++ b/includes/install.mysql.inc
@@ -31,6 +31,7 @@ function drupal_test_mysql($url, &$success) {
   $url['pass'] = isset($url['pass']) ? urldecode($url['pass']) : '';
   $url['host'] = urldecode($url['host']);
   $url['path'] = urldecode($url['path']);
+  $url['port'] = isset($url['port']) ? $url['port'] : NULL;
 
   // Allow for non-standard MySQL port.
   if (isset($url['port'])) {

--- a/includes/install.mysqli.inc
+++ b/includes/install.mysqli.inc
@@ -31,6 +31,7 @@ function drupal_test_mysqli($url, &$success) {
   $url['pass'] = isset($url['pass']) ? urldecode($url['pass']) : '';
   $url['host'] = urldecode($url['host']);
   $url['path'] = urldecode($url['path']);
+  $url['port'] = isset($url['port']) ? $url['port'] : NULL;
 
   $connection = mysqli_init();
   @mysqli_real_connect($connection, $url['host'], $url['user'], $url['pass'], substr($url['path'], 1), $url['port'], NULL, MYSQLI_CLIENT_FOUND_ROWS);

--- a/includes/unicode.inc
+++ b/includes/unicode.inc
@@ -318,6 +318,25 @@ function _mime_header_decode($matches) {
 }
 
 /**
+ * Simple class to use instead of closure in decode_entities().
+ *
+ * @see decode_entities()
+ */
+class DrupalDecodeEntitiesCallback {
+  public $html_entities;
+  public $exclude;
+
+  public function __construct($html_entities, $exclude) {
+    $this->html_entities = $html_entities;
+    $this->exclude = $exclude;
+  }
+
+  public function callback($matches) {
+    return _decode_entities($matches[1], $matches[2], $matches[0], $this->html_entities, $this->exclude);
+  }
+}
+
+/**
  * Decodes all HTML entities (including numerical ones) to regular UTF-8 bytes.
  *
  * Double-escaped entities will only be decoded once ("&amp;lt;" becomes "&lt;",
@@ -342,11 +361,12 @@ function decode_entities($text, $exclude = array()) {
   // Flip the exclude list so that we can do quick lookups later.
   $exclude = array_flip($exclude);
 
+  // Use object instead of closure to retain PHP 5.2 compatibility.
+  $callback = new DrupalDecodeEntitiesCallback($html_entities, $exclude);
+
   // Use a regexp to select all entities in one pass, to avoid decoding 
-  // double-escaped entities twice. The PREG_REPLACE_EVAL modifier 'e' is
-  // being used to allow for a callback (see 
-  // http://php.net/manual/en/reference.pcre.pattern.modifiers).
-  return preg_replace('/&(#x?)?([A-Za-z0-9]+);/e', '_decode_entities("$1", "$2", "$0", $html_entities, $exclude)', $text);
+  // double-escaped entities twice.
+  return preg_replace_callback('/&(#x?)?([A-Za-z0-9]+);/', array($callback, 'callback'), $text);
 }
 
 /**

--- a/install.php
+++ b/install.php
@@ -655,7 +655,7 @@ function install_tasks($profile, $task) {
   global $base_url, $install_locale;
 
   // Bootstrap newly installed Drupal, while preserving existing messages.
-  $messages = isset($_SESSION['messages']) ? $_SESSION['messages'] : '';
+  $messages = isset($_SESSION['messages']) ? $_SESSION['messages'] : array();
   drupal_bootstrap(DRUPAL_BOOTSTRAP_FULL);
   $_SESSION['messages'] = $messages;
 

--- a/modules/statistics/statistics.module
+++ b/modules/statistics/statistics.module
@@ -176,7 +176,7 @@ function statistics_user($op, &$edit, &$user) {
  * Implementation of hook_cron().
  */
 function statistics_cron() {
-  $statistics_timestamp = variable_get('statistics_day_timestamp', '');
+  $statistics_timestamp = variable_get('statistics_day_timestamp', 0);
 
   if ((time() - $statistics_timestamp) >= 86400) {
     // Reset day counts.

--- a/modules/system/system.module
+++ b/modules/system/system.module
@@ -8,7 +8,7 @@
 /**
  * The current system version.
  */
-define('VERSION', '6.44');
+define('VERSION', '6.45');
 
 /**
  * Core API compatibility.

--- a/modules/taxonomy/taxonomy.pages.inc
+++ b/modules/taxonomy/taxonomy.pages.inc
@@ -29,6 +29,7 @@ function taxonomy_term_page($str_tids = '', $depth = 0, $op = 'page') {
 
       switch ($op) {
         case 'page':
+          $current = new stdClass();
           // Build breadcrumb based on first hierarchy of first term:
           $current->tid = $tids[0];
           $breadcrumb = array();

--- a/modules/upload/upload.module
+++ b/modules/upload/upload.module
@@ -278,7 +278,7 @@ function upload_nodeapi(&$node, $op, $teaser = NULL) {
     case 'load':
       $output = '';
       if (variable_get("upload_$node->type", 1) == 1) {
-        $output['files'] = upload_load($node);
+        $output = array('files' => upload_load($node));
         return $output;
       }
       break;

--- a/sites/default/default.settings.php
+++ b/sites/default/default.settings.php
@@ -160,7 +160,6 @@ ini_set('session.cache_expire',     200000);
 ini_set('session.cache_limiter',    'none');
 ini_set('session.cookie_lifetime',  2000000);
 ini_set('session.gc_maxlifetime',   200000);
-ini_set('session.save_handler',     'user');
 ini_set('session.use_cookies',      1);
 ini_set('session.use_only_cookies', 1);
 ini_set('session.use_trans_sid',    0);


### PR DESCRIPTION
So, Drupal 6.45 was released to add PHP 7 support. Unfortunately, we haven't had a chance to really test PHP 7 with Pressflow 6. But here's the same changes applied to Pressflow, which at the very least shouldn't be harmful, and will help to keep the version numbers in sync.